### PR TITLE
Fix repeated word in about page metadata

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,13 +8,13 @@
   <link rel="icon" href="img/favicon.png">
   <link rel="stylesheet" href="style.css">
   <link rel="canonical" href="https://ztatlock.net/about.html">
-<meta name="description" content="Zachary Tatlock is a computer scientist interested in programming languages, running, knitting, and helping out around the the UW Allen School.">
+<meta name="description" content="Zachary Tatlock is a computer scientist interested in programming languages, running, knitting, and helping out around the UW Allen School.">
 
 <!-- OpenGraph -->
 <meta property="og:url" content="https://ztatlock.net/about.html">
 <meta property="og:type" content="website">
 <meta property="og:title" content="Zachary Tatlock / About">
-<meta property="og:description" content="Computer scientist interested in programming languages, running, knitting, and helping out around the the UW Allen School.">
+<meta property="og:description" content="Computer scientist interested in programming languages, running, knitting, and helping out around the UW Allen School.">
 <meta property="og:image" content="https://ztatlock.net/img/2015-12-plse-faculty-baja-hoodies.jpg">
 
 <!-- Twitter -->
@@ -22,7 +22,7 @@
 <meta property="twitter:domain" content="ztatlock.net/about.html">
 <meta property="twitter:url" content="https://ztatlock.net/">
 <meta name="twitter:title" content="Zachary Tatlock / About">
-<meta name="twitter:description" content="Computer scientist interested in programming languages, running, knitting, and helping out around the the UW Allen School.">
+<meta name="twitter:description" content="Computer scientist interested in programming languages, running, knitting, and helping out around the UW Allen School.">
 <meta name="twitter:image" content="https://ztatlock.net/img/2015-12-plse-faculty-baja-hoodies.jpg">
   <script async src="https://analytics.umami.is/script.js" data-website-id="e9f6fa87-a4bb-48ac-84df-b2d190867eb9" data-domains="ztatlock.net"></script>
 </head>

--- a/about.meta
+++ b/about.meta
@@ -1,10 +1,10 @@
-<meta name="description" content="Zachary Tatlock is a computer scientist interested in programming languages, running, knitting, and helping out around the the UW Allen School.">
+<meta name="description" content="Zachary Tatlock is a computer scientist interested in programming languages, running, knitting, and helping out around the UW Allen School.">
 
 <!-- OpenGraph -->
 <meta property="og:url" content="https://ztatlock.net/about.html">
 <meta property="og:type" content="website">
 <meta property="og:title" content="Zachary Tatlock / About">
-<meta property="og:description" content="Computer scientist interested in programming languages, running, knitting, and helping out around the the UW Allen School.">
+<meta property="og:description" content="Computer scientist interested in programming languages, running, knitting, and helping out around the UW Allen School.">
 <meta property="og:image" content="https://ztatlock.net/img/2015-12-plse-faculty-baja-hoodies.jpg">
 
 <!-- Twitter -->
@@ -12,5 +12,5 @@
 <meta property="twitter:domain" content="ztatlock.net/about.html">
 <meta property="twitter:url" content="https://ztatlock.net/">
 <meta name="twitter:title" content="Zachary Tatlock / About">
-<meta name="twitter:description" content="Computer scientist interested in programming languages, running, knitting, and helping out around the the UW Allen School.">
+<meta name="twitter:description" content="Computer scientist interested in programming languages, running, knitting, and helping out around the UW Allen School.">
 <meta name="twitter:image" content="https://ztatlock.net/img/2015-12-plse-faculty-baja-hoodies.jpg">


### PR DESCRIPTION
## Summary
- fix `the the` typo in About page description fields

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a12a123248321bae5bb68cf574ff9